### PR TITLE
TinymceBundle 0.3.0 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ibrows_newsletter:
 stfalcon_tinymce:
   include_jquery: false
   tinymce_jquery: true
-  textarea_class: "tinymce"
+  selector: ".tinymce"
   # create own methods in your own RendererBridge and set here the icons and description for them
   tinymce_buttons:
     unsubscribelink:


### PR DESCRIPTION
TinymceBundle UPGRADE FROM 0.2.1 to 0.3.0 wants to use `selector: ".tinymce"` instead of `textarea_class: "tinymce"`.